### PR TITLE
feat: stage 3 - custom range delimiters

### DIFF
--- a/number_range_expander.py
+++ b/number_range_expander.py
@@ -1,35 +1,51 @@
+from typing import List, Optional
+
 class NumberRangeExpander:
+    def __init__(self, delimiters: Optional[List[str]] = None):
+        self.delimiters = delimiters if delimiters else ['-', 'to', '..', '~']
     
     def _parse_part(self, part: str):
         part = part.strip()
-        
         if not part:
             return []
         
-        dash_index = -1
-        for i, char in enumerate(part):
+        for delimiter in self.delimiters:
     
-            if char == '-':
-                
-                if i == 0:
-                    # If this is the first character, it's a negative number
-                    if i + 1 < len(part) and part[i + 1].isdigit():
-                        continue
-                    else:
-                        raise ValueError(f"Invalid range format: '{part}'")
+            part_ = part.split(delimiter)
+            
+            if len(part_) > 2:
+                dash_index = -1
+                prev_= None
+                for i, char in enumerate(part):
         
-                elif part[i-1].isdigit() and i + 1 < len(part) and not part[i + 1].isspace():
-                    dash_index = i
-                    break
+                    if char == delimiter:
 
-        if dash_index != -1:
-            start_str = part[:dash_index]
-            end_str = part[dash_index + 1:]
-            start = int(start_str)
-            end = int(end_str)
-            return list(range(start, end + 1))
-        else:
-            return [int(part)]
+                        if i == 0:
+                            # If this is the first character, it's a negative number
+                            if i + 1 < len(part) and part[i + 1].isdigit():
+                                continue
+
+                        elif prev_:
+                            dash_index = i
+                            break
+                    elif char.isdigit():
+                        prev_ = char
+                    elif not char.isspace():
+                        prev_ = None
+                
+                if dash_index != -1:
+                    start_str = part[:dash_index]
+                    end_str = part[dash_index + 1:]
+                    start = int(start_str)
+                    end = int(end_str)
+                    return list(range(start, end + 1))
+            elif len(part_) == 2 and part_[0].strip():
+                start_str, end_str = part_
+                start = int(start_str.strip())
+                end = int(end_str.strip())
+                return list(range(start, end + 1))
+        
+        return [int(part)]
     
     def expand(self, input_string: str):
         if not input_string:
@@ -52,7 +68,7 @@ class NumberRangeExpander:
 if __name__ == "__main__":
     """Command-line interface for the Number Range Expander."""
     import argparse
-    expander = NumberRangeExpander()
+    
     parser = argparse.ArgumentParser(
         description="Expand number sequences and ranges from string input",
         formatter_class=argparse.RawDescriptionHelpFormatter,
@@ -65,6 +81,15 @@ if __name__ == "__main__":
         "input_string",
         help="String containing numbers and ranges to expand"
     )
+    
+    parser.add_argument(
+        "--delimiters", "-d",
+        nargs="+",
+        default=["-", "..", "to", "~"],
+        help="Range delimiters (default: - .. to ~)"
+    )
+    
     args = parser.parse_args()
+    expander = NumberRangeExpander(delimiters=args.delimiters)
     expanded_numbers = expander.expand(args.input_string)
     print(expanded_numbers)

--- a/test_range_expander.py
+++ b/test_range_expander.py
@@ -76,6 +76,46 @@ class TestStage2IgnoreWhitespaceAndEmptyParts(unittest.TestCase):
         """Test empty part around negative numbers."""
         result = self.expander.expand(" -2   , 4 ")
         self.assertEqual(result, [-2, 4])
-        
+
+
+class TestStage3CustomRangeDelimiters(unittest.TestCase):
+    """Test Stage 3: Custom Range Delimiters functionality."""
+    
+    def setUp(self):
+        """Set up test fixtures."""
+        self.expander = NumberRangeExpander()
+    
+    def test_dot_dot_delimiter(self):
+        """Test '..' delimiter."""
+        result = self.expander.expand("1..3")
+        self.assertEqual(result, [1, 2, 3])
+    
+    def test_tilde_delimiter(self):
+        """Test '~' delimiter."""
+        result = self.expander.expand("4~6")
+        self.assertEqual(result, [4, 5, 6])
+    
+    def test_to_delimiter(self):
+        """Test 'to' delimiter."""
+        result = self.expander.expand("10 to 12")
+        self.assertEqual(result, [10, 11, 12])
+    
+    def test_mixed_delimiters(self):
+        """Test mixed range delimiters in one string."""
+        result = self.expander.expand("1-3,4..6,7~9")
+        self.assertEqual(result, [1, 2, 3, 4, 5, 6, 7, 8, 9])
+    
+    def test_custom_delimiters(self):
+        """Test custom delimiter configuration."""
+        custom_expander = NumberRangeExpander(delimiters=["->", "until"])
+        result = custom_expander.expand("1 -> 3,5 until 7")
+        self.assertEqual(result, [1, 2, 3, 5, 6, 7])
+    
+    def test_delimiter_precedence(self):
+        """Test that longer delimiters take precedence."""
+        result = self.expander.expand("1..5")
+        self.assertEqual(result, [1, 2, 3, 4, 5])
+
+
 if __name__ == "__main__":
     unittest.main(verbosity=2)


### PR DESCRIPTION
## Stage 3: Custom Range Delimiters
- Support alternate range delimiters like "..", "to", "~"
- These should be configurable (not hardcoded).
### Example:
- "1..3" → [1, 2, 3]
- "4~6" → [4, 5, 6]
- "10 to 12" → [10, 11, 12]