### PR TITLE
feat: Stage 4- handle reversed or invalid ranges gracefully

### DIFF
--- a/number_range_expander.py
+++ b/number_range_expander.py
@@ -38,11 +38,15 @@ class NumberRangeExpander:
                     end_str = part[dash_index + 1:]
                     start = int(start_str)
                     end = int(end_str)
+                    if start > end:
+                        return list(range(end, start + 1))[::-1]
                     return list(range(start, end + 1))
             elif len(part_) == 2 and part_[0].strip():
                 start_str, end_str = part_
                 start = int(start_str.strip())
                 end = int(end_str.strip())
+                if start > end:
+                    return list(range(end, start + 1))[::-1]
                 return list(range(start, end + 1))
         
         return [int(part)]

--- a/test_range_expander.py
+++ b/test_range_expander.py
@@ -116,6 +116,27 @@ class TestStage3CustomRangeDelimiters(unittest.TestCase):
         result = self.expander.expand("1..5")
         self.assertEqual(result, [1, 2, 3, 4, 5])
 
+class TestStage4HandleReversedorInvalidRangesGracefully(unittest.TestCase):
+    """Test Stage 4: Error Handling functionality."""
+    
+    def setUp(self):
+        """Set up test fixtures."""
+        self.expander = NumberRangeExpander()
+    
+    def test_reverse_order_range(self):
+        """Test handling of invalid ranges."""
+        result = self.expander.expand("5..1")
+        self.assertEqual(result, [5, 4, 3, 2, 1])
+    
+    def test_non_numeric_input(self):
+        """Test handling of non-numeric input."""
+        with self.assertRaises(ValueError):
+            self.expander.expand("a-b")
+    
+    def test_mixed_valid_and_invalid_ranges(self):
+        """Test handling of mixed valid and invalid ranges."""
+        with self.assertRaises(ValueError):
+            self.expander.expand("1-3,5,a-7")
 
 if __name__ == "__main__":
     unittest.main(verbosity=2)


### PR DESCRIPTION
## Stage 4: Handle Reversed or Invalid Ranges Gracefully
- Handle reversed ranges: "5-3" → [5, 4, 3] or raise an error
- Handle single-point ranges: "3-3" → [3]
- Validate that ranges contain only numeric values
### Example: "3-a" should raise an error